### PR TITLE
feat: 支持自定义 IDE 名称

### DIFF
--- a/src/main/java/com/github/blingyshs/openincursor/OpenInCursorAction.kt
+++ b/src/main/java/com/github/blingyshs/openincursor/OpenInCursorAction.kt
@@ -35,14 +35,14 @@ class OpenInCursorAction : AnAction() {
         val projectPath = project.basePath
         // 获取当前文件路径
         val filePath = virtualFile.path
-        
+
         // 使用设置中的配置
         val settings = OpenInCursorSettings.getInstance()
         val openInNewWindow = if (settings.openInNewWindow) "?windowId=_blank" else ""
 
         try {
-            // 首先打开项目根目录
-            val projectUrl = "cursor://file/$projectPath$openInNewWindow"
+            // 使用配置的 IDE 名称打开项目根目录
+            val projectUrl = "${settings.ideName}://file/$projectPath$openInNewWindow"
             Desktop.getDesktop().browse(URI(projectUrl))
 
             // 使用配置的延迟时间
@@ -54,7 +54,7 @@ class OpenInCursorAction : AnAction() {
                         // 获取当前行号
                         val lineNumber = editor?.caretModel?.logicalPosition?.line
                         // 打开文件
-                        val fileUrl = "cursor://file/$filePath:${lineNumber?.plus(1) ?: 1}"
+                        val fileUrl = "${settings.ideName}://file/$filePath:${lineNumber?.plus(1) ?: 1}"
                         System.out.println("打开文件: $fileUrl")
                         log.info("打开文件: $fileUrl")
                         Desktop.getDesktop().browse(URI(fileUrl))

--- a/src/main/java/com/github/blingyshs/openincursor/OpenInCursorSettings.kt
+++ b/src/main/java/com/github/blingyshs/openincursor/OpenInCursorSettings.kt
@@ -10,6 +10,7 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 class OpenInCursorSettings : PersistentStateComponent<OpenInCursorSettings> {
     var delaySeconds: Int = 3
     var openInNewWindow: Boolean = true
+    var ideName: String = "cursor"
 
     override fun getState(): OpenInCursorSettings = this
 
@@ -20,4 +21,4 @@ class OpenInCursorSettings : PersistentStateComponent<OpenInCursorSettings> {
     companion object {
         fun getInstance(): OpenInCursorSettings = service()
     }
-} 
+}

--- a/src/main/java/com/github/blingyshs/openincursor/OpenInCursorSettingsConfigurable.kt
+++ b/src/main/java/com/github/blingyshs/openincursor/OpenInCursorSettingsConfigurable.kt
@@ -1,15 +1,10 @@
 package com.github.blingyshs.openincursor
 
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.options.Configurable
-import javax.swing.JComponent
-import javax.swing.JPanel
-import javax.swing.JLabel
-import javax.swing.JSpinner
-import javax.swing.SpinnerNumberModel
+import com.intellij.ui.components.JBLabel
 import java.awt.FlowLayout
-import javax.swing.JCheckBox
-import javax.swing.BoxLayout
-import javax.swing.JTextField
+import javax.swing.*
 
 class OpenInCursorSettingsConfigurable : Configurable {
     private var settingsComponent: OpenInCursorSettingsComponent? = null
@@ -24,8 +19,8 @@ class OpenInCursorSettingsConfigurable : Configurable {
     override fun isModified(): Boolean {
         val settings = OpenInCursorSettings.getInstance()
         return settingsComponent!!.delaySeconds != settings.delaySeconds ||
-               settingsComponent!!.openInNewWindow != settings.openInNewWindow ||
-               settingsComponent!!.ideName != settings.ideName
+                settingsComponent!!.openInNewWindow != settings.openInNewWindow ||
+                settingsComponent!!.ideName != settings.ideName
     }
 
     override fun apply() {
@@ -55,17 +50,10 @@ class OpenInCursorSettingsComponent {
 
     init {
         panel.layout = FlowLayout(FlowLayout.LEFT)
-        
+
         // 创建一个垂直布局的面板
         val mainPanel = JPanel()
         mainPanel.layout = BoxLayout(mainPanel, BoxLayout.Y_AXIS)
-
-        // ide 名称设置
-        val ideNamePanel = JPanel(FlowLayout(FlowLayout.LEFT))
-        ideNamePanel.add(JLabel("IDE名称:"))
-        ideNameField = JTextField(10)
-        ideNamePanel.add(ideNameField)
-        mainPanel.add(ideNamePanel)
 
         // 延迟设置
         val delayPanel = JPanel(FlowLayout(FlowLayout.LEFT))
@@ -73,12 +61,25 @@ class OpenInCursorSettingsComponent {
         delaySpinner = JSpinner(SpinnerNumberModel(2, 1, 10, 1))
         delayPanel.add(delaySpinner)
         mainPanel.add(delayPanel)
-        
+
         // 新窗口选项
         val newWindowPanel = JPanel(FlowLayout(FlowLayout.LEFT))
         newWindowCheckBox = JCheckBox("在新窗口中打开当前项目")
         newWindowPanel.add(newWindowCheckBox)
         mainPanel.add(newWindowPanel)
+
+        // IDE协议名称设置
+        val ideNamePanel = JPanel(FlowLayout(FlowLayout.LEFT))
+        ideNamePanel.add(JLabel("IDE协议名称:"))
+        ideNameField = JTextField(10)
+        ideNamePanel.add(ideNameField)
+        // 添加带有提示的感叹号图标
+        val warningLabel = JBLabel(AllIcons.General.BalloonInformation)
+        warningLabel.toolTipText =
+            "你可以填写任何 VSCode Like 的 IDE 协议名称，如：windsurf，vscode。如果你不知道这个是什么，请不要修改它"
+        ideNamePanel.add(warningLabel)
+
+        mainPanel.add(ideNamePanel)
 
         panel.add(mainPanel)
     }

--- a/src/main/java/com/github/blingyshs/openincursor/OpenInCursorSettingsConfigurable.kt
+++ b/src/main/java/com/github/blingyshs/openincursor/OpenInCursorSettingsConfigurable.kt
@@ -9,6 +9,7 @@ import javax.swing.SpinnerNumberModel
 import java.awt.FlowLayout
 import javax.swing.JCheckBox
 import javax.swing.BoxLayout
+import javax.swing.JTextField
 
 class OpenInCursorSettingsConfigurable : Configurable {
     private var settingsComponent: OpenInCursorSettingsComponent? = null
@@ -23,19 +24,22 @@ class OpenInCursorSettingsConfigurable : Configurable {
     override fun isModified(): Boolean {
         val settings = OpenInCursorSettings.getInstance()
         return settingsComponent!!.delaySeconds != settings.delaySeconds ||
-               settingsComponent!!.openInNewWindow != settings.openInNewWindow
+               settingsComponent!!.openInNewWindow != settings.openInNewWindow ||
+               settingsComponent!!.ideName != settings.ideName
     }
 
     override fun apply() {
         val settings = OpenInCursorSettings.getInstance()
         settings.delaySeconds = settingsComponent!!.delaySeconds
         settings.openInNewWindow = settingsComponent!!.openInNewWindow
+        settings.ideName = settingsComponent!!.ideName
     }
 
     override fun reset() {
         val settings = OpenInCursorSettings.getInstance()
         settingsComponent!!.delaySeconds = settings.delaySeconds
         settingsComponent!!.openInNewWindow = settings.openInNewWindow
+        settingsComponent!!.ideName = settings.ideName
     }
 
     override fun disposeUIResources() {
@@ -47,6 +51,7 @@ class OpenInCursorSettingsComponent {
     val panel: JPanel = JPanel()
     private val delaySpinner: JSpinner
     private val newWindowCheckBox: JCheckBox
+    private val ideNameField: JTextField  // 新增
 
     init {
         panel.layout = FlowLayout(FlowLayout.LEFT)
@@ -54,22 +59,35 @@ class OpenInCursorSettingsComponent {
         // 创建一个垂直布局的面板
         val mainPanel = JPanel()
         mainPanel.layout = BoxLayout(mainPanel, BoxLayout.Y_AXIS)
-        
-        // 第一行：延迟设置
+
+        // ide 名称设置
+        val ideNamePanel = JPanel(FlowLayout(FlowLayout.LEFT))
+        ideNamePanel.add(JLabel("IDE名称:"))
+        ideNameField = JTextField(10)
+        ideNamePanel.add(ideNameField)
+        mainPanel.add(ideNamePanel)
+
+        // 延迟设置
         val delayPanel = JPanel(FlowLayout(FlowLayout.LEFT))
         delayPanel.add(JLabel("打开文件延迟时间（秒）:"))
         delaySpinner = JSpinner(SpinnerNumberModel(2, 1, 10, 1))
         delayPanel.add(delaySpinner)
         mainPanel.add(delayPanel)
         
-        // 第二行：新窗口选项
+        // 新窗口选项
         val newWindowPanel = JPanel(FlowLayout(FlowLayout.LEFT))
-        newWindowCheckBox = JCheckBox("在 Cursor 的新窗口中打开当前项目")
+        newWindowCheckBox = JCheckBox("在新窗口中打开当前项目")
         newWindowPanel.add(newWindowCheckBox)
         mainPanel.add(newWindowPanel)
-        
+
         panel.add(mainPanel)
     }
+
+    var ideName: String
+        get() = ideNameField.text
+        set(value) {
+            ideNameField.text = value
+        }
 
     var delaySeconds: Int
         get() = delaySpinner.value as Int


### PR DESCRIPTION
- 允许用户在设置中指定 IDE 名称，用于打开项目和文件
- 使用配置的 IDE 名称替换原先的 "cursor" 协议
- 更新设置界面，新增 IDE 名称输入框

Closes: #12